### PR TITLE
Updated to match PWM_test.v functionality

### DIFF
--- a/avalon_wrapper.v
+++ b/avalon_wrapper.v
@@ -24,11 +24,13 @@ module avalon_wrapper (
 	assign avs_s0_readdata = read_data;
 	
 	PWM_core PWM_core0(
-		.clk(csi_clk), 
 		.reset(rsi_rst_n),
-		.pulse_period(period),
+		.clk(csi_clk), 
 		.switch_in(pulse_width),
-		.out(pwm_out)
+		.pulse_period(period),
+		.byteenable(4'b1111),
+		.out(pwm_out)//,
+		//.out_pin(pwm_out)
 	);
 	
 	/*


### PR DESCRIPTION
Main change is now sending byteenable to PWM_Core. Also added second output for GPIO pin, but commented out for now.